### PR TITLE
Add prometheus support

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -3,13 +3,8 @@ use futures_util::{future::join, pin_mut, select, FutureExt};
 use lazy_static::lazy_static;
 use std::sync::{Arc, Mutex};
 use tokio::signal;
-use rocket_prometheus::prometheus::{
-    register_int_gauge_vec,
-    IntGaugeVec,
-    register_int_counter_vec,
-    IntCounterVec,
-};
 
+mod metrics;
 mod connections;
 mod web;
 
@@ -17,17 +12,6 @@ lazy_static! {
     static ref REFS: Arc<Mutex<Vec<connections::LoopRef>>> = Arc::new(Mutex::new(vec![]));
     static ref DB: MollySocketDb = MollySocketDb::new().unwrap();
     static ref TX: Arc<Mutex<connections::OptSender>> = Arc::new(Mutex::new(None));
-
-    static ref METRIC_MOLLYSOCKET_UP: IntGaugeVec =
-         register_int_gauge_vec!("mollysocket_up", "Is Mollysocket ready", &["version"]).unwrap();
-
-    static ref METRIC_MOLLYSOCKET_SIGNAL_CONNECTED: IntGaugeVec =
-         register_int_gauge_vec!("mollysocket_signal_connected", "Connected to signal", &["type","uuid","push_endpoint"]).unwrap();
-    static ref METRIC_MOLLYSOCKET_SIGNAL_RECONNECTED: IntCounterVec =
-         register_int_counter_vec!("mollysocket_signal_reconnected", "reconnected to signal", &["type","uuid","push_endpoint"]).unwrap();
-
-    static ref METRIC_MOLLYSOCKET_PUSH: IntCounterVec =
-         register_int_counter_vec!("mollysocket_push", "send (unified) push message", &["type","uuid","push_endpoint"]).unwrap();
 }
 
 pub async fn run() {

--- a/src/server/metrics.rs
+++ b/src/server/metrics.rs
@@ -1,0 +1,54 @@
+
+use crate::CONFIG;
+
+use lazy_static::lazy_static;
+use rocket::{
+    Rocket,
+    Build,
+};
+
+use rocket_prometheus::{
+    PrometheusMetrics,
+    prometheus::{
+        register_int_gauge_vec,
+        IntGaugeVec,
+        register_int_counter_vec,
+        IntCounterVec,
+    },
+};
+
+lazy_static! {
+    pub static ref METRIC_MOLLYSOCKET_UP: IntGaugeVec =
+         register_int_gauge_vec!("mollysocket_up", "Is Mollysocket ready", &["version"]).unwrap();
+
+    pub static ref METRIC_MOLLYSOCKET_SIGNAL_CONNECTED: IntGaugeVec =
+         register_int_gauge_vec!("mollysocket_signal_connected", "Connected to signal", &["type","uuid","push_endpoint"]).unwrap();
+    pub static ref METRIC_MOLLYSOCKET_SIGNAL_RECONNECTED: IntCounterVec =
+         register_int_counter_vec!("mollysocket_signal_reconnected", "reconnected to signal", &["type","uuid","push_endpoint"]).unwrap();
+
+    pub static ref METRIC_MOLLYSOCKET_PUSH: IntCounterVec =
+         register_int_counter_vec!("mollysocket_push", "send (unified) push message", &["type","uuid","push_endpoint"]).unwrap();
+}
+
+pub fn rocket(server: Rocket<Build>) -> Rocket<Build> {
+    let prometheus = PrometheusMetrics::new();
+    let prom_registry = prometheus.registry();
+    prom_registry
+        .register(Box::new(METRIC_MOLLYSOCKET_UP.clone()))
+        .unwrap();
+    prom_registry
+        .register(Box::new(METRIC_MOLLYSOCKET_SIGNAL_CONNECTED.clone()))
+        .unwrap();
+    prom_registry
+        .register(Box::new(METRIC_MOLLYSOCKET_SIGNAL_RECONNECTED.clone()))
+        .unwrap();
+    prom_registry
+        .register(Box::new(METRIC_MOLLYSOCKET_PUSH.clone()))
+        .unwrap();
+
+    // set metric values (should be an rocket guard later if multiple metrics are there)
+    METRIC_MOLLYSOCKET_UP.with_label_values(&[CONFIG.version.as_str()]).set(1);
+
+    server.attach(prometheus.clone())
+        .mount("/metrics", prometheus)
+}


### PR DESCRIPTION
fixes #3 

Add also custom Metric:
```
# HELP mollysocket_up Is Mollysocket ready
# TYPE mollysocket_up gauge
mollysocket_up{version="0.1.0"} 1
# HELP mollysocket_signal_connected Connected to signal
# TYPE mollysocket_signal_connected gauge
mollysocket_signal_connected{type="Websocket",uuid="43db7325-37f9-4183-a614-9f0d4a02b142"} 1
```

Add default rocket metric endpoints (for find slow endpoint / path) - Rename metrics with ENV-Variable `ROCKET_PROMETHEUS_NAMESPACE` (default `rocket`) from `rocket_*` to `mollysocket_*` is possible:
```
# HELP rocket_http_requests_duration_seconds HTTP request duration in seconds for all requests
# TYPE rocket_http_requests_duration_seconds histogram
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.005"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.01"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.025"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.05"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.1"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.25"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="0.5"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="1"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="2.5"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="5"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="10"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="GET",status="200",le="+Inf"} 31
rocket_http_requests_duration_seconds_sum{endpoint="/",method="GET",status="200"} 0.0038883740000000004
rocket_http_requests_duration_seconds_count{endpoint="/",method="GET",status="200"} 31
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="0.005"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="0.01"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="0.025"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="0.05"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="0.1"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="0.25"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="0.5"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="1"} 6
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="2.5"} 7
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="5"} 7
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="10"} 7
rocket_http_requests_duration_seconds_bucket{endpoint="/",method="POST",status="200",le="+Inf"} 7
rocket_http_requests_duration_seconds_sum{endpoint="/",method="POST",status="200"} 2.928642397
rocket_http_requests_duration_seconds_count{endpoint="/",method="POST",status="200"} 7
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.005"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.01"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.025"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.05"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.1"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.25"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="0.5"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="1"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="2.5"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="5"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="10"} 5
rocket_http_requests_duration_seconds_bucket{endpoint="/metrics",method="GET",status="200",le="+Inf"} 5
rocket_http_requests_duration_seconds_sum{endpoint="/metrics",method="GET",status="200"} 0.001272728
rocket_http_requests_duration_seconds_count{endpoint="/metrics",method="GET",status="200"} 5
# HELP rocket_http_requests_total Total number of HTTP requests
# TYPE rocket_http_requests_total counter
rocket_http_requests_total{endpoint="/",method="GET",status="200"} 31
rocket_http_requests_total{endpoint="/",method="POST",status="200"} 7
rocket_http_requests_total{endpoint="/metrics",method="GET",status="200"} 5
```